### PR TITLE
Google Guice Inject implementations as singletons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.3 (February 22, 2021)
+
+* Fixed issue [Publish exceptions under load #63](https://github.com/elasticio/sailor-jvm/issues/63)
+
 ## 3.3.2 (February 2, 2021)
 
 * Fixed a bug when a credentials verification reason was not displayed on the UI 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 group = 'io.elastic'
-version = '3.3.3'
+version = '3.3.4-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 group = 'io.elastic'
-version = '3.3.3-SNAPSHOT'
+version = '3.3.3'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 sourceCompatibility = 1.8

--- a/src/main/java/io/elastic/sailor/impl/MessagePublisherImpl.java
+++ b/src/main/java/io/elastic/sailor/impl/MessagePublisherImpl.java
@@ -1,6 +1,7 @@
 package io.elastic.sailor.impl;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
@@ -15,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
+@Singleton
 public class MessagePublisherImpl implements MessagePublisher {
 
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(MessagePublisherImpl.class);


### PR DESCRIPTION
#63  
Guice defaults to providing a new instance of a defined dependency. But sailor should use one MessagePublisher to manage opening/closing channels in the correct way.

Test results after applied improvement:
![image](https://user-images.githubusercontent.com/13310949/108737882-b4b1bf00-753b-11eb-9a77-7bba09b8163a.png)
![image](https://user-images.githubusercontent.com/13310949/108737841-a9f72a00-753b-11eb-9bc1-a7e99fdb362d.png)

