### PR TITLE
Fix(core): Handle JsonArray and null in MessageResolverImpl body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.1 (December 26, 2025)
+  * Fixed ClassCastException in MessageResolverImpl when message body was a JSON array, and gracefully handle missing or null message bodies.
+
 ## 5.0.0 (November 14, 2025)
   * **Concurrency & Stability Fixes:**
     * Added retry mechanism for publisher confirms on timeout to prevent message loss.

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = 'io.elastic'
-version = '5.0.0'
+version = '5.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 def isCiEnv = 'true'.equals(System.getenv('CI'))

--- a/src/main/java/io/elastic/sailor/impl/MessageResolverImpl.java
+++ b/src/main/java/io/elastic/sailor/impl/MessageResolverImpl.java
@@ -276,7 +276,12 @@ public class MessageResolverImpl implements MessageResolver {
         public MessageHolder(final String stepId, final JsonObject message) {
             this.stepId = stepId;
             this.message = message;
-            this.bodyStr = message.getJsonObject(Message.PROPERTY_BODY).toString();
+            final JsonValue body = message.get(Message.PROPERTY_BODY);
+            if (body == null || body.getValueType() == JsonValue.ValueType.NULL) {
+                this.bodyStr = Json.createObjectBuilder().build().toString();
+            } else {
+                this.bodyStr = body.toString();
+            }
         }
 
     }

--- a/src/test/groovy/io/elastic/sailor/impl/MessageResolverImplSpec.groovy
+++ b/src/test/groovy/io/elastic/sailor/impl/MessageResolverImplSpec.groovy
@@ -325,4 +325,25 @@ class MessageResolverImplSpec extends Specification {
         JSON.stringify(result) == '{"id":"9d843898-2799-47bd-bede-123dd5d755ee","attachments":{},"body":{},"headers":{"x-ipaas-object-storage-id":"58876284571c810019c78ef7"},"passthrough":{"step_1":{"id":"82317293-fcae-4d1f-9bc9-25aa8913f9f3","attachments":{},"body":{},"headers":{"foo":"bar","x-ipaas-object-storage-id":"588763137d802200192b485c"},"passthrough":{}}}}'
 
     }
+
+    def "should externalize successfully with array body"() {
+        setup:
+
+        def body = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder().add("row", 1))
+                .add(Json.createObjectBuilder().add("row", 2))
+                .build()
+
+        def msg = Json.createObjectBuilder()
+                .add("id", "9d843898-2799-47bd-bede-123dd5d755ee")
+                .add("body", body)
+                .build()
+
+        when:
+        def result = resolver.externalize(msg)
+
+        then:
+        1 * storage.post('[{"row":1},{"row":2}]', "main message body") >> Json.createObjectBuilder().add("objectId", "58876284571c810019c78ef7").build()
+        JSON.stringify(result) == '{"id":"9d843898-2799-47bd-bede-123dd5d755ee","body":{},"headers":{"x-ipaas-object-storage-id":"58876284571c810019c78ef7"},"passthrough":{}}'
+    }
 }


### PR DESCRIPTION
Fixes a ClassCastException when the message body received from RabbitMQ is a JsonArray instead of a JsonObject.

Also, gracefully handles missing or null message bodies by defaulting to an empty JSON object, preventing NullPointerExceptions in such cases.

The  file was also updated to align with the new project version.